### PR TITLE
Fix 401 redirect logic

### DIFF
--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -52,10 +52,10 @@ api.interceptors.response.use(
 
       switch (status) {
         case 401:
-          // Unauthorized - redirect to login
+          // Unauthorized - clear token and reload
           localStorage.removeItem('auth_token');
-          window.location.href = '/login';
           toast.error('Session expired. Please login again.');
+          window.location.href = '/';
           break;
 
         case 403:

--- a/frontend/src/stores/authStore.js
+++ b/frontend/src/stores/authStore.js
@@ -14,15 +14,15 @@ export const useAuthStore = create(
         token,
       }),
       
-      logout: () => {
-        localStorage.removeItem('auth_token');
-        set({
-          user: null,
-          isAuthenticated: false,
-          token: null,
-        });
-        window.location.href = '/login';
-      },
+        logout: () => {
+          localStorage.removeItem('auth_token');
+          set({
+            user: null,
+            isAuthenticated: false,
+            token: null,
+          });
+          window.location.href = '/';
+        },
       
       updateUser: (userData) => set((state) => ({
         user: { ...state.user, ...userData },


### PR DESCRIPTION
## Summary
- stop redirecting to non-existent `/login` route in api service
- update auth store logout action to go to the root instead of `/login`

## Testing
- `npm --prefix frontend run lint` *(fails: ESLint couldn't find configuration)*
- `npm --prefix frontend run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bdb38b4648323a0e618a01bb706ec